### PR TITLE
Fixes Fidelity Linking

### DIFF
--- a/TradeItIosTicketSDK2/TradeItYahooLauncher.swift
+++ b/TradeItIosTicketSDK2/TradeItYahooLauncher.swift
@@ -16,7 +16,7 @@ import SafariServices
     private let cryptoTradingUIFlow = TradeItYahooCryptoTradingUIFlow()
     private let oAuthCompletionUIFlow = TradeItYahooOAuthCompletionUIFlow()
     private let linkBrokerUIFlow = TradeItYahooLinkBrokerUIFlow()
-    private let alertManager = TradeItAlertManager()
+    private let alertManager = TradeItAlertManager(linkBrokerUIFlow: TradeItYahooLinkBrokerUIFlow())
 
     weak var delegate: YahooLauncherDelegate?
 


### PR DESCRIPTION
Relinks from the alertManger didn't use the Yahoo linking flow so the linking bug still exists for certain actions. 

Cause of the bug seems to be missing dependency injection.